### PR TITLE
Fix(nltk): Prevent false dead onion skips by downloading punkt_tab

### DIFF
--- a/darkdump.py
+++ b/darkdump.py
@@ -44,6 +44,7 @@ from banner.banner import Banner
 import nltk
 nltk.download('stopwords')
 nltk.download('punkt')
+nltk.download('punkt_tab')
 
 from nltk.corpus import stopwords
 from nltk.tokenize import word_tokenize
@@ -145,7 +146,7 @@ class Darkdump(object):
         word_tokens = word_tokenize(clean_text.lower())
         filtered_text = [word for word in word_tokens if word.isalnum() and not word in stop_words]
         freq_dist = FreqDist(filtered_text)
-        keywords = list(freq_dist)[:18] 
+        keywords = list(freq_dist)[:18]
         return keywords
 
     def analyze_text(self, text):
@@ -254,7 +255,6 @@ class Darkdump(object):
                     try:
                         site_response = requests.get(site_url, headers=headers, proxies=proxy_config)
                         site_soup = BeautifulSoup(site_response.content, 'html.parser')
-
                         text_analysis = self.analyze_text(site_soup.get_text())
                         metadata = self.extract_metadata(site_soup)
                         links = self.extract_links(site_soup)


### PR DESCRIPTION
## Summary

This PR fixes a runtime error where `analyze_text(site_soup.get_text())` fails due to a missing NLTK resource: `punkt_tab`.

## Details

- Although `nltk.download('punkt')` is already present it doesn't properly register the `punkt_tab` resource.
- This leads to a `LookupError`, which causes all .onion sites to be incorrectly skipped as "Dead onion" due to the exception handler.
- Explicitly adding `nltk.download('punkt_tab')` resolves the issue.

## Result

`.onion` sites are now properly processed, and content can be analyzed without triggering false negatives.

Tested in:
- ✅ Kali Linux
- ✅ Python 3.12
- ✅ Tor proxy at 127.0.0.1:9050

Let me know if you'd like this implemented differently.
