### PR TITLE
Feat(cli): Add --debug argument to show full exception details

### DIFF
--- a/darkdump.py
+++ b/darkdump.py
@@ -220,7 +220,7 @@ class Darkdump(object):
         return links
 
 
-    def crawl(self, query, amount, use_proxy=False, scrape_sites=False, scrape_images=False):
+    def crawl(self, query, amount, use_proxy=False, scrape_sites=False, scrape_images=False, debug_mode=False):
         headers = {'User-Agent': random.choice(Headers.user_agents)}
         proxy_config = {'http': 'socks5h://localhost:9050', 'https': 'socks5h://localhost:9050'} if use_proxy else {}
 
@@ -287,7 +287,9 @@ class Darkdump(object):
 
                     except Exception as e: 
                         print(f"{Colors.BOLD + Colors.O} Dead onion, skipping...: {site_url} {Colors.END}")
-
+                        if debug_mode:
+                            print(f"{Colors.BOLD + Colors.R}[DEBUG] Exception: {e}{Colors.END}")
+	
                 else: # No scrape
                     print(f"{Colors.BOLD}{idx + 1}. --- [+] Website: {Colors.END}{Colors.P}{title.strip()}{Colors.END}")
                     print(f"{Colors.BOLD}\t Information: {Colors.END}{Colors.G}{description.strip()}{Colors.END}")
@@ -314,6 +316,7 @@ def darkdump_main():
     parser.add_argument("-p", "--proxy", help="use tor proxy for scraping", action="store_true")
     parser.add_argument("-i", "--images", help="scrape images and visual content from the site", action="store_true")
     parser.add_argument("-s", "--scrape", help="scrape the actual site for content and look for keywords", action="store_true")
+    parser.add_argument("-d", "--debug", help="enable debug output", action="store_true")
 
     args = parser.parse_args()
 
@@ -330,9 +333,12 @@ def darkdump_main():
         parser.print_help()
         sys.exit(1)
 
+    if args.debug:
+        print(f"{Colors.R}DEBUG mode is on.{Colors.W}")
+
     if args.query:
         print(f"Searching For: {args.query} and showing {args.amount} results...\nIndexing is viable, skipping dead onions.\n")
-        Darkdump().crawl(args.query, args.amount, use_proxy=args.proxy, scrape_sites=args.scrape, scrape_images=args.images)
+        Darkdump().crawl(args.query, args.amount, use_proxy=args.proxy, scrape_sites=args.scrape, scrape_images=args.images, debug_mode=args.debug)
     else:
         print("[~] Note: No query arguments were passed. Please supply a query to search.")
 


### PR DESCRIPTION
## Summary

This PR adds a `--debug` argument to Darkdump's CLI to assist with debugging scraping failures, especially those that silently fail due to resource or network errors.

## Behavior

When `--debug` is enabled, full exception tracebacks are printed, such as:

![圖片](https://github.com/user-attachments/assets/96396330-1152-4217-a6c8-cdc5a6f8a834)

## Why

This helps developers and users diagnose issues such as missing NLTK resources or misconfigurations, which would otherwise appear as silent "Dead onion" skips without any visible error.