### PR TITLE
fix(cli): correct result count and reject non-positive --amount

### DIFF
--- a/darkdump.py
+++ b/darkdump.py
@@ -239,7 +239,7 @@ class Darkdump(object):
         if scrape_sites: 
             if Platform(True).check_tor_connection(proxy_config) == False: return
 
-        for idx, result in enumerate(second_results[:min(amount + 1, len(second_results))], start=1):
+        for idx, result in enumerate(second_results[:min(amount, len(second_results))], start=1):
             site_url = result.find('cite').text
             if "http://" not in site_url and "https://" not in site_url:
                 site_url = "http://" + site_url
@@ -270,7 +270,7 @@ class Darkdump(object):
                             images_str = f"{Colors.BOLD}| Images Gallery: {Colors.END}{Colors.G}{os.path.abspath(html_path)}{Colors.END}\n"
 
                         print('-' * 50)
-                        print(f"{Colors.BOLD}{idx + 1}.\n --- [+] Website: {Colors.END}{Colors.P}{title.strip()}{Colors.END}")
+                        print(f"{Colors.BOLD}{idx}.\n --- [+] Website: {Colors.END}{Colors.P}{title.strip()}{Colors.END}")
                         print(f"{Colors.BOLD}| Information: {Colors.END}{Colors.G}{description.strip()}{Colors.END}")
                         print(f"{Colors.BOLD}| Onion Link: {Colors.END}{Colors.G}{site_url}{Colors.END}")
                         print(f"{Colors.BOLD}| Keywords: {Colors.END}{Colors.G}{', '.join(self.extract_keywords(site_soup.get_text()))}{Colors.END}")
@@ -289,7 +289,7 @@ class Darkdump(object):
                         print(f"{Colors.BOLD + Colors.O} Dead onion, skipping...: {site_url} {Colors.END}")
 
                 else: # No scrape
-                    print(f"{Colors.BOLD}{idx + 1}. --- [+] Website: {Colors.END}{Colors.P}{title.strip()}{Colors.END}")
+                    print(f"{Colors.BOLD}{idx}. --- [+] Website: {Colors.END}{Colors.P}{title.strip()}{Colors.END}")
                     print(f"{Colors.BOLD}\t Information: {Colors.END}{Colors.G}{description.strip()}{Colors.END}")
                     print(f"{Colors.BOLD}| Onion Link: {Colors.END}{Colors.G}{site_url}{Colors.END}\n")
 
@@ -328,6 +328,10 @@ def darkdump_main():
     if args.images and not args.scrape:
         print(Colors.BOLD + Colors.R + "Error: Images option '-i' must be used with the scraping option '-s'." + Colors.END)
         parser.print_help()
+        sys.exit(1)
+
+    if args.amount <= 0:
+        print(f"{Colors.BOLD + Colors.R}Error: Amount must be a positive integer.{Colors.END}")
         sys.exit(1)
 
     if args.query:


### PR DESCRIPTION
## Summary

This PR addresses two issues related to the `-a / --amount` argument:

1. **Off-by-one error**:  
   Previously, passing `-a 10` would result in 11 results being printed due to `amount + 1` being used during slicing.  
   This has been corrected so that the actual number of results shown matches the user-defined value.

2. **No validation for negative or zero values**:  
   Passing `-a -1` or `-a 0` previously led to incorrect behavior or no results with no warning.  
   A new input validation has been added to ensure the value of `--amount` must be a positive integer.

## Before

```bash
python3 darkdump.py -q hacking -a 10
# → Prints 11 results

python3 darkdump.py -q hacking -a -1
# → Unexpected behavior (e.g. no results or crash)
```

## After
```bash
python3 darkdump.py -q hacking -a 10
# → Prints exactly 10 results

python3 darkdump.py -q hacking -a -1
# → Error: Amount must be a positive integer.
```
![圖片](https://github.com/user-attachments/assets/8df75731-4fc4-4dcb-9ea8-92f7a6cc98fc)